### PR TITLE
feat: state extract ID from `desc=` in `.state()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ onboarding_pathway = (
         activation="user is a new customer or mentions account setup",
         completion_criteria="customer account is fully configured and ready to use"
     )
-    # === STATE: welcome ===
-    .state("welcome customer and collect basic information", id="welcome")
+    # === STATE: initial ===
+    .state("initial: welcome customer and collect basic information")
     .required([
         "customer's full name",
         "email address",
@@ -295,7 +295,7 @@ onboarding_pathway = (
     .next_state("setup")
 
     # === STATE: setup ===
-    .state("configure account preferences", id="setup")
+    .state("setup: configure account preferences")
     .required([
         "password created and confirmed",
         "notification preferences selected",
@@ -306,7 +306,7 @@ onboarding_pathway = (
     .next_state("tour")
 
     # === STATE: tour ===
-    .state("provide guided tour of key features", id="tour")
+    .state("tour: provide guided tour of key features")
     .required(["main features demonstrated", "first task completed"])
     .success_condition("customer understands how to use core functionality")
 )

--- a/docs/user-guide/pathways.qmd
+++ b/docs/user-guide/pathways.qmd
@@ -32,7 +32,7 @@ pathway = (
         fallback_strategy="how to handle edge cases"
     )
     # === STATE: state_name ===
-    .state("description of what happens", id="state_name")
+    .state("state name: description of what happens")
     .required(["essential information needed"])
     .optional(["helpful but not required info"])
     .success_condition("How to know this state is complete")
@@ -58,7 +58,7 @@ onboarding = (
     )
 
     # === STATE: welcome ===
-    .state("welcome customer and collect basic information", id="welcome")
+    .state("welcome: welcome customer and collect basic information")
     .required([
         "customer's full name",
         "email address",
@@ -68,7 +68,7 @@ onboarding = (
     .next_state("setup")
 
     # === STATE: setup ===
-    .state("configure account preferences", id="setup")
+    .state("setup: configure account preferences")
     .required([
         "password created and confirmed",
         "notification preferences selected",
@@ -79,7 +79,7 @@ onboarding = (
     .next_state("tour")
 
     # === STATE: tour ===
-    .state("provide guided tour of key features", id="tour")
+    .state("tour: provide guided tour of key features")
     .required(["main features demonstrated", "first task completed"])
     .success_condition("customer understands how to use core functionality")
 )
@@ -94,14 +94,18 @@ The pathway uses clear, specific requirements at each step (like `"password crea
 
 ## State Types and Inference
 
-Pathways automatically infer state types based on the methods you use:
+Pathways automatically infer both state types and IDs based on the methods you use and the shorthand syntax:
+
+- **State Types**: Inferred from method usage (`.required()` → `"collect"`, `.branch_on()` → `"decision"`, `.tools()` → `"tool"`)
+- **State IDs**: Extracted from `"id: description"` format, with automatic normalization (spaces → underscores)
+- **State Blocks**: Method calls between `.state()` definitions belong to the previous state, creating natural configuration blocks
 
 ### Collection States (`type="collect"`)
 
 Automatically inferred when using `.required()` or `.optional()`:
 
 ```python
-.state("Gather project requirements", id="requirements")
+.state("requirements: gather project requirements")
 .required(["project goals", "timeline", "budget range"])
 .optional(["preferred technologies", "team size"])
 # Type automatically inferred as "collect"
@@ -114,7 +118,7 @@ Collection states are perfect for systematic information gathering. When you spe
 Automatically inferred when using `.branch_on()`:
 
 ```python
-.state("determine support type needed", id="triage")
+.state("triage: determine support type needed")
 .branch_on("technical issue reported", id="tech_support")
 .branch_on("billing question asked", id="billing")
 .branch_on("general inquiry", id="general_help")
@@ -128,7 +132,7 @@ Decision states create conditional pathways based on user responses or circumsta
 Automatically inferred when using `.tools()`:
 
 ```python
-.state("analyze system performance", id="diagnostics")
+.state("diagnostics: analyze system performance")
 .tools(["system_monitor", "log_analyzer", "performance_profiler"])
 .success_condition("performance issues identified")
 # Type automatically inferred as "tool"
@@ -141,7 +145,7 @@ Tool states enable external capabilities and automated processes. When you speci
 The default for open conversation, explanations, and guidance:
 
 ```python
-.state("explain the recommended solution", id="explanation")
+.state("explanation: explain the recommended solution")
 .success_condition("customer understands the approach")
 # Remains as default "chat" type
 ```
@@ -161,31 +165,31 @@ support_pathway = (
     )
 
     # === STATE: assessment ===
-    .state("assess customer needs", id="assessment")
+    .state("assessment: assess customer needs")
     .required(["issue description", "urgency level", "customer type"])
     .next_state("triage")
 
     # === STATE: triage ===
-    .state("route to appropriate support", id="triage")
+    .state("triage: route to appropriate support")
     .branch_on("critical system outage", id="emergency")
     .branch_on("technical issue needing expert help", id="technical")
     .branch_on("billing or account question", id="billing")
     .branch_on("general question or guidance needed", id="general")
 
     # === STATE: emergency ===
-    .state("handle critical emergency", id="emergency")
+    .state("emergency: handle critical emergency")
     .required(["incident escalated", "immediate response initiated"])
     .success_condition("emergency team engaged")
     .next_state("follow_up")
 
     # === STATE: technical ===
-    .state("provide technical support", id="technical")
+    .state("technical: provide technical support")
     .tools(["diagnostic_tools", "knowledge_base", "screen_sharing"])
     .success_condition("technical issue resolved or escalated appropriately")
     .next_state("follow_up")
 
     # === STATE: follow_up ===
-    .state("ensure customer satisfaction", id="follow_up")
+    .state("follow up: ensure customer satisfaction")
     .required(["resolution confirmed", "satisfaction rating collected"])
     .success_condition("customer issue fully resolved")
 )
@@ -204,13 +208,13 @@ problem_solving = (
     )
 
     # === STATE: analysis ===
-    .state("analyze the reported problem", id="analysis")
+    .state("analysis: analyze the reported problem")
     .required(["problem details", "error messages", "system context"])
     .success_condition("problem is clearly understood")
     .next_state("standard_solution")
 
     # === STATE: standard_solution ===
-    .state("apply standard troubleshooting steps", id="standard_solution")
+    .state("standard solution: apply standard troubleshooting steps")
     .required(["troubleshooting steps completed", "results documented"])
     .success_condition("problem is resolved")
 
@@ -219,7 +223,7 @@ problem_solving = (
     .next_state("completion")
 
     # === STATE: advanced_diagnostics ===
-    .state("perform detailed system analysis", id="advanced_diagnostics")
+    .state("advanced diagnostics: perform detailed system analysis")
     .tools(["system_diagnostics", "log_analyzer", "network_tracer"])
     .success_condition("root cause identified and resolved")
 
@@ -228,13 +232,13 @@ problem_solving = (
     .next_state("completion")
 
     # === STATE: escalation ===
-    .state("escalate to specialist support", id="escalation")
+    .state("escalation: escalate to specialist support")
     .required(["detailed case summary", "specialist contacted"])
     .success_condition("case transferred successfully")
     .next_state("completion")
 
     # === STATE: completion ===
-    .state("document resolution and close case", id="completion")
+    .state("completion: document resolution and close case")
     .required(["resolution documented", "customer notified"])
     .success_condition("case fully resolved and documented")
 )
@@ -254,10 +258,10 @@ support_pathway = (
         desc="comprehensive customer assistance",
         activation="Customer needs help",
     )
-    .state("understand customer needs", id="intake")
+    .state("intake: understand customer needs")
     .required(["problem description", "contact information"])
     .next_state("resolution")
-    .state("provide solution", id="resolution")
+    .state("resolution: provide solution")
     .success_condition("customer problem is resolved")
 )
 
@@ -285,10 +289,10 @@ response = bot.chat("I'm having trouble with my account")
 
 ```python
 # Good: Specific and actionable
-.state("collect shipping address and delivery preferences", id="shipping")
+.state("shipping: collect shipping address and delivery preferences")
 
 # Avoid: Vague or unclear
-.state("Get info", id="info")
+.state("info: get info")
 ```
 
 Clear, descriptive state names help both AI models and human developers understand the purpose and scope of each step. When state descriptions are specific, the AI can better guide conversations toward the intended outcomes and provide appropriate responses to user questions.
@@ -325,10 +329,10 @@ Success conditions should describe observable user behaviors or confirmations ra
 
 ```python
 # Good: Descriptive and unique
-.state("review order details and confirm purchase", id="order_confirmation")
+.state("order confirmation: review order details and confirm purchase")
 
 # Avoid: Generic or confusing
-.state("process order", id="process")
+.state("process: process order")
 ```
 
 State IDs serve as navigation waypoints and debugging references throughout your pathway logic. Descriptive names make it easier to understand pathway flow, troubleshoot issues, and maintain complex conversation structures over time.
@@ -337,11 +341,11 @@ State IDs serve as navigation waypoints and debugging references throughout your
 
 ```python
 # Good: Progressive information gathering
-.state("collect basic contact info", id="contact")
+.state("contact: collect basic contact info")
 .required(["name", "email"])
 .next_state("detailed_requirements")
 
-.state("gather detailed project requirements", id="detailed_requirements")
+.state("detailed requirements: gather detailed project requirements")
 .required(["project scope", "timeline", "budget"])
 # Builds on previous information
 ```
@@ -359,19 +363,19 @@ Different branches can reconverge to common states:
 ```{python}
 pathway = (
     tb.Pathways(title="Multi-path Process", desc="...")
-    .state("initial assessment", id="assessment")
+    .state("assessment: initial assessment")
     .branch_on("path A condition", id="path_a")
     .branch_on("path B condition", id="path_b")
 
-    .state("handle path A", id="path_a")
+    .state("path a: handle path A")
     .required(["path A requirements"])
     .next_state("completion")  # Converge here
 
-    .state("handle path B", id="path_b")
+    .state("path b: handle path B")
     .required(["path B requirements"])
     .next_state("completion")  # Converge here
 
-    .state("complete process", id="completion")
+    .state("completion: complete process")
     .success_condition("all paths lead to successful completion")
 )
 ```
@@ -385,21 +389,21 @@ Reveal complexity gradually:
 ```{python}
 complex_setup = (
     tb.Pathways(title="System Configuration", desc="...")
-    .state("basic setup", id="basic")
+    .state("basic: basic setup")
     .required(["essential settings configured"])
     .next_state("intermediate")
 
-    .state("intermediate configuration", id="intermediate")
+    .state("intermediate: intermediate configuration")
     .required(["advanced options reviewed"])
     .optional(["performance tuning preferences"])
     .branch_on("user wants advanced setup", id="advanced")
     .next_state("completion")  # Skip advanced if not needed
 
-    .state("advanced configuration", id="advanced")
+    .state("advanced: advanced configuration")
     .required(["expert settings configured"])
     .next_state("completion")
 
-    .state("finalize setup", id="completion")
+    .state("completion: finalize setup")
     .success_condition("System is fully configured and tested")
 )
 ```

--- a/talk_box/pathways.py
+++ b/talk_box/pathways.py
@@ -113,15 +113,15 @@ class Pathways:
             activation="User needs help"
         )
         # === STATE: intake ===
-        .state("Gather customer information", id="intake")
+        .state("intake: gather customer information")
         .required(["issue description", "contact info"])
         .next_state("triage")
         # === STATE: triage ===
-        .state("Route to appropriate support", id="triage")
+        .state("triage: route to appropriate support")
         .branch_on("Technical issue", id="tech_support")
         .branch_on("Billing question", id="billing")
         # === STATE: tech_support ===
-        .state("Resolve technical problems", id="tech_support")
+        .state("tech support: resolve technical problems")
         .success_condition("Issue resolved")
     )
     ```
@@ -129,7 +129,7 @@ class Pathways:
     This approach provides:
 
     - visual state boundaries with `# === STATE: description ===` comments
-    - natural state definition with description first: `.state("What happens here", id="name")`
+    - natural state definition with shorthand syntax: `.state("id: what happens here")`
     - smart type inference where `.tools()` → `"tool"`, `.branch_on()` → `"decision"`,
     `.required()` → `"collect"`
     - automatic start state where the first `.state()` becomes the starting state
@@ -142,7 +142,7 @@ class Pathways:
         .state("info: collect required information")            # inferred as "collect", id="info"
         .state("make decision: evaluate options and choose")    # "make decision" → id="make_decision"
         .state("use tools: apply specific capabilities")        # type inferred as "tool" from .tools()
-        .state("final summary: provide conclusion", type="summary")  # explicit type with semantic sugar
+        .state("final summary: provide conclusion", type="summary")  # explicit type with shorthand syntax
         .state("Wrap up")                                       # Linear states don't really need IDs
 
         # Configure the state
@@ -201,11 +201,11 @@ class Pathways:
             fallback_strategy="If user lacks access to recovery methods, escalate to manual verification"
         )
         # === STATE: verification ===
-        .state("Verify user identity", id="verification")
+        .state("verification: verify user identity")
         .required(["email address", "account verification"])
         .next_state("password_update")
         # === STATE: password_update ===
-        .state("Guide user through creating new password", id="password_update")
+        .state("password update: guide user through creating new password")
         .required(["new password is created", "password requirements are met"])
         .success_condition("User successfully logs in with new password")
     )
@@ -230,21 +230,21 @@ class Pathways:
             fallback_strategy="if issue is complex, escalate to human support"
         )
         # === STATE: triage ===
-        .state("determine the type of support needed", id="triage")
+        .state("triage: determine the type of support needed")
         .branch_on("Technical problem reported", id="technical_support")
         .branch_on("Billing question asked", id="billing_support")
         .branch_on("General inquiry made", id="general_help")
         # === STATE: technical_support ===
-        .state("diagnose and resolve technical issues", id="technical_support")
+        .state("technical support: diagnose and resolve technical issues")
         .tools(["system_diagnostics", "troubleshooting_guide"])
         .success_condition("Technical issue is resolved")
         .next_state("completion")
         # === STATE: billing_support ===
         .state("billing support: address billing and account questions")
         .required(["billing issue is understood", "solution is provided"])
-        .next_state("final_summary")
-        # === STATE: final_summary ===
-        .state("final summary: ensure customer satisfaction and wrap up", type="summary")
+        .next_state("completion")
+        # === STATE: completion ===
+        .state("completion: ensure customer satisfaction and wrap up", type="summary")
         .required(["issue resolved confirmation", "follow up if needed"])
         .success_condition("Customer satisfaction confirmed")
     )
@@ -343,14 +343,15 @@ class Pathways:
         desc
             Clear description of the state's purpose and what should happen. This is the primary
             identifier and should be specific about the expected interaction or outcome. Supports
-            semantic sugar: use `"id: description"` format to specify both ID and description in
+            shorthand syntax: use `"id: description"` format to specify both ID and description in
             one parameter (e.g., `"completion: ensure customer satisfaction and wrap up"`). The ID
             part will be automatically normalized (spaces converted to underscores, etc.).
         id
             Optional unique identifier for the state. Required only when other states need to
             reference this state (via `.branch_on()`, `.next_state()`). If not
-            provided, an ID will be auto-generated from the description. Ignored if `desc` uses
-            the `"id: description"` format.
+            provided, an ID will be extracted from `desc` using `"id: description"` format if
+            present, otherwise auto-generated. If explicitly provided, shorthand parsing
+            is bypassed.
         type
             Optional explicit state type. If not provided, the type will be inferred from subsequent
             method calls
@@ -383,8 +384,9 @@ class Pathways:
         -----------------
         - **Description Priority**: description always comes first as the primary identifier
         - **Reference Requirements**: ID only needed when other states need to reference this state
-        - **Semantic Sugar**: use `"id: description"` format to combine ID and description in one
+        - **Shorthand Syntax**: use `"id: description"` format to combine ID and description in one
         parameter for cleaner syntax; ID part is automatically normalized (spaces → underscores)
+        - **Explicit ID Priority**: when `id=` parameter is provided, shorthand parsing is bypassed
         - **Type Inference**: inferred from usage patterns to reduce explicit configuration
         - **Conflict Resolution**: first method call determines type, conflicts generate warnings
         - **Auto-generation**: IDs use `snake_case` from description with uniqueness guarantees
@@ -402,7 +404,7 @@ class Pathways:
 
         Examples
         --------
-        Complete pathway showing `.state()` method with both traditional and semantic sugar syntax:
+        Complete pathway showing `.state()` method with both traditional and shorthand syntax:
 
         ```{python}
         import talk_box as tb
@@ -417,20 +419,20 @@ class Pathways:
 
             # Traditional syntax: separate id parameter ---
             # === STATE: welcome ===
-            .state("welcome customer and understand their situation", id="welcome")
+            .state("welcome: welcome customer and understand their situation")
             .required(["the customer's goal", "a budget range"])
             .next_state("needs_analysis")
 
-            # Semantic sugar: "id: description" format ---
+            # Shorthand syntax: "id: description" format ---
             # === STATE: needs_analysis ===
-            .state("needs analysis: analyze customer requirements and preferences")  # "needs analysis" → "needs_analysis"
+            .state("needs analysis: analyze customer requirements and preferences")
             .required(["specific requirements", "priorities"])
             .success_condition("customer needs are clearly understood")
             .next_state("final_recommendation")
 
             # Spaces in ID automatically become underscores ---
             # === STATE: final_recommendation ===
-            .state("final recommendation: present tailored product matches")  # "final recommendation" → "final_recommendation"
+            .state("final recommendation: present tailored product matches")
             .required(["product matches", "rationale"])
             .success_condition("customer has clear next steps")
         )
@@ -441,7 +443,7 @@ class Pathways:
         """
         import re
 
-        # Parse semantic sugar: "id: description" format
+        # Parse shorthand syntax: "id: description" format
         if id is None and ":" in desc:
             # Check if desc follows "id: description" pattern
             parts = desc.split(":", 1)
@@ -618,14 +620,14 @@ class Pathways:
                 activation="customer wants to apply for a loan"
             )
             # === STATE: personal_info ===
-            .state("gather basic applicant information", id="personal_info")
+            .state("personal info: gather basic applicant information")
 
             # .required() ensures critical data is collected ---
             .required(["applicant's full name", "current employment status"])
 
             .next_state("financial_details")
             # === STATE: financial_details ===
-            .state("collect financial information", id="financial_details")
+            .state("financial details: collect financial information")
 
             # .required() can specify multiple essential items ---
 
@@ -639,7 +641,7 @@ class Pathways:
             .success_condition("All financial data verified")
             .next_state("review")
             # === STATE: review ===
-            .state("review application completeness", id="review")
+            .state("review: review application completeness")
 
             # .required() works with single items too ---
             .required("applicant's legal signature and consent")
@@ -712,7 +714,7 @@ class Pathways:
                 activation="customer wants to book a flight"
             )
             # === STATE: travel_basics ===
-            .state("gather essential travel details", id="travel_basics")
+            .state("travel basics: gather essential travel details")
             .required(["departure city", "destination city", "preferred travel date"])
 
             # .optional() adds helpful details without slowing the process -----
@@ -724,7 +726,7 @@ class Pathways:
 
             .next_state("search_flights")
             # === STATE: search_flights ===
-            .state("find matching flights", id="search_flights")
+            .state("search flights: find matching flights")
             .required("available flight options found and presented")
 
             # .optional() can improve personalization ---
@@ -733,7 +735,7 @@ class Pathways:
             .success_condition("customer has reviewed flight options")
             .next_state("booking")
             # === STATE: booking ===
-            .state("complete the booking", id="booking")
+            .state("booking: complete the booking")
             .required(["valid payment information", "complete traveler details for all passengers"])
 
             # .optional() for enhanced services ---
@@ -807,11 +809,11 @@ class Pathways:
                 activation="user reports technical problems"
             )
             # === STATE: problem_intake ===
-            .state("understand the reported issue", id="problem_intake")
+            .state("problem intake: understand the reported issue")
             .required(["problem description", "system details", "error messages"])
             .next_state("initial_diagnosis")
             # === STATE: initial_diagnosis ===
-            .state("run initial diagnostic checks", id="initial_diagnosis")
+            .state("initial diagnosis: run initial diagnostic checks")
 
             # .tools() specifies what capabilities are available ---
             .tools([
@@ -823,7 +825,7 @@ class Pathways:
             .success_condition("initial diagnosis completed")
             .next_state("detailed_analysis")
             # === STATE: detailed_analysis ===
-            .state("perform detailed system analysis", id="detailed_analysis")
+            .state("detailed analysis: perform detailed system analysis")
 
             # .tools() can specify advanced diagnostic tools ---
             .tools([
@@ -835,7 +837,7 @@ class Pathways:
             .required(["the root cause is identified"])
             .next_state("solution")
             # === STATE: solution ===
-            .state("implement solution", id="solution")
+            .state("solution: implement solution")
 
             # .tools() for implementation capabilities ---
             .tools("automated_repair_tool")
@@ -907,7 +909,7 @@ class Pathways:
                 activation="student completes a learning module"
             )
             # === STATE: practice ===
-            .state("present practice problems", id="practice")
+            .state("practice: present practice problems")
             .required(["problems are attempted", "student provided responses"])
 
             # .success_condition() defines when understanding is demonstrated ---
@@ -915,7 +917,7 @@ class Pathways:
 
             .next_state("feedback")
             # === STATE: feedback ===
-            .state("provide personalized feedback", id="feedback")
+            .state("feedback: provide personalized feedback")
             .required(["specific feedback", "improvement areas"])
 
             # .success_condition() ensures feedback is constructive ---
@@ -923,7 +925,7 @@ class Pathways:
 
             .next_state("advanced_practice")
             # === STATE: advanced_practice ===
-            .state("offer advanced challenges", id="advanced_practice")
+            .state("advanced practice: offer advanced challenges")
             .required("challenging problems are presented")
             .optional("hints if needed")
 
@@ -988,14 +990,14 @@ class Pathways:
                 activation="new customer signs up"
             )
             # === STATE: welcome ===
-            .state("welcome and collect basic information", id="welcome")
+            .state("welcome: welcome and collect basic information")
             .required(["full name", "email", "company name"])
 
             # .next_state() creates smooth linear progression ---
             .next_state("account_setup")
 
             # === STATE: account_setup ===
-            .state("set up account preferences", id="account_setup")
+            .state("account setup: set up account preferences")
             .required(["password is created", "preferences are selected"])
             .success_condition("account is fully configured")
 
@@ -1003,7 +1005,7 @@ class Pathways:
             .next_state("feature_tour")
 
             # === STATE: feature_tour ===
-            .state("provide guided feature tour", id="feature_tour")
+            .state("feature tour: provide guided feature tour")
             .required("key features are demonstrated")
             .success_condition("customer understands main functionality")
 
@@ -1011,7 +1013,7 @@ class Pathways:
             .next_state("completion")
 
             # === STATE: completion ===
-            .state("complete onboarding process", id="completion")
+            .state("completion: complete onboarding process")
             .required(["welcome resources are provided", "next steps are explained"])
             .success_condition("customer is ready to use the platform")
         )
@@ -1078,12 +1080,12 @@ class Pathways:
                 activation="patient seeks medical assistance"
             )
             # === STATE: initial_assessment ===
-            .state("assess patient symptoms and urgency", id="initial_assessment")
+            .state("initial assessment: assess patient symptoms and urgency")
             .required(["symptoms are described", "pain level", "duration"])
             .success_condition("Symptoms are clearly documented")
             .next_state("triage_decision")
             # === STATE: triage_decision ===
-            .state("determine appropriate care level", id="triage_decision")
+            .state("triage decision: determine appropriate care level")
             .required("urgency is evaluated")
 
             # .branch_on() routes based on severity -----
@@ -1093,26 +1095,26 @@ class Pathways:
 
             # The first branch leads to emergency care -----
             # === STATE: emergency_care ===
-            .state("initiate emergency protocol", id="emergency_care")
+            .state("emergency care: initiate emergency protocol")
             .required(["911 is called", "immediate first aid is provided"])
             .success_condition("emergency services are contacted")
             .next_state("follow_up")
 
             # The second branch leads to urgent care -----
             # === STATE: urgent_care ===
-            .state("schedule urgent care appointment", id="urgent_care")
+            .state("urgent care: schedule urgent care appointment")
             .required(["same day appointment", "preparation instructions"])
             .success_condition("urgent care is arranged")
             .next_state("follow_up")
 
             # The third branch leads to standard care -----
             # === STATE: standard_care ===
-            .state("provide self-care guidance", id="standard_care")
+            .state("standard care: provide self-care guidance")
             .required(["home care instructions", "symptom monitoring"])
             .success_condition("patient understands self-care plan")
             .next_state("follow_up")
             # === STATE: follow_up ===
-            .state("arrange follow-up care", id="follow_up")
+            .state("follow up: arrange follow-up care")
             .required(["follow up is scheduled"])
             .success_condition("continuity of care is ensured")
         )
@@ -1181,12 +1183,12 @@ class Pathways:
                 activation="user encounters a technical problem"
             )
             # === STATE: problem_analysis ===
-            .state("understand the problem details", id="problem_analysis")
+            .state("problem analysis: understand the problem details")
             .required(["problem description", "system context", "error details"])
             .success_condition("problem is clearly defined")
             .next_state("solution_attempt")
             # === STATE: solution_attempt ===
-            .state("apply standard solution", id="solution_attempt")
+            .state("solution attempt: apply standard solution")
             .required(["solution is implemented", "results are verified"])
             .success_condition("problem is resolved")
 
@@ -1195,7 +1197,7 @@ class Pathways:
 
             .next_state("completion")
             # === STATE: advanced_troubleshooting ===
-            .state("advanced diagnostic procedures", id="advanced_troubleshooting")
+            .state("advanced troubleshooting: advanced diagnostic procedures")
             .tools(["system_diagnostics", "log_analyzer", "network_tracer"])
             .required("root cause is identified")
             .success_condition("advanced solution is implemented")
@@ -1206,12 +1208,12 @@ class Pathways:
             .next_state("completion")
 
             # === STATE: expert_escalation ===
-            .state("escalate to specialist support", id="expert_escalation")
+            .state("expert escalation: escalate to specialist support")
             .required(["detailed case summary", "expert is contacted"])
             .success_condition("case is transferred to appropriate specialist")
             .next_state("completion")
             # === STATE: completion ===
-            .state("confirm resolution and document", id="completion")
+            .state("completion: confirm resolution and document")
             .required(["resolution is confirmed", "case is documented"])
             .success_condition("issue fully resolved and documented")
         )

--- a/talk_box/pathways.py
+++ b/talk_box/pathways.py
@@ -103,7 +103,7 @@ class Pathways:
         # First .state() call automatically becomes the starting state
     ```
 
-    ### 2. State Definition (using unified `.state()`method)
+    ### 2. State Definition
 
     ```python
     pathway = (
@@ -139,11 +139,11 @@ class Pathways:
     ```python
         # Define the state with description first
         .state("What happens in this state", id="state_name")
-        .state("Gather information", id="state_name")  # type inferred as "collect" from .required()
-        .state("Make decisions", id="state_name")      # type inferred as "decision" from .branch_on()
-        .state("Use tools/APIs", id="state_name")      # type inferred as "tool" from .tools()
-        .state("Provide final summary", id="summary_state", type="summary")  # explicit type
-        .state("Wrap up")                              # Linear states don't need IDs
+        .state("info: collect required information")            # inferred as "collect", id="info"
+        .state("make decision: evaluate options and choose")    # "make decision" → id="make_decision"
+        .state("use tools: apply specific capabilities")        # type inferred as "tool" from .tools()
+        .state("final summary: provide conclusion", type="summary")  # explicit type with semantic sugar
+        .state("Wrap up")                                       # Linear states don't really need IDs
 
         # Configure the state
         .required([...])                               # What must be accomplished
@@ -224,27 +224,27 @@ class Pathways:
     support_pathway = (
         tb.Pathways(
             title="Customer Support",
-            desc="Route and resolve customer inquiries",
-            activation=["User needs help", "User reports problem"],
-            completion_criteria=["Customer issue fully resolved", "Customer satisfied"],
-            fallback_strategy="If issue is complex, escalate to human support"
+            desc="route and resolve customer inquiries",
+            activation=["user needs help", "user reports problem"],
+            completion_criteria=["customer issue fully resolved", "customer satisfied"],
+            fallback_strategy="if issue is complex, escalate to human support"
         )
         # === STATE: triage ===
-        .state("Determine the type of support needed", id="triage")
+        .state("determine the type of support needed", id="triage")
         .branch_on("Technical problem reported", id="technical_support")
         .branch_on("Billing question asked", id="billing_support")
         .branch_on("General inquiry made", id="general_help")
         # === STATE: technical_support ===
-        .state("Diagnose and resolve technical issues", id="technical_support")
+        .state("diagnose and resolve technical issues", id="technical_support")
         .tools(["system_diagnostics", "troubleshooting_guide"])
         .success_condition("Technical issue is resolved")
         .next_state("completion")
         # === STATE: billing_support ===
-        .state("Address billing and account questions", id="billing_support")
+        .state("billing support: address billing and account questions")
         .required(["billing issue is understood", "solution is provided"])
-        .next_state("completion")
-        # === STATE: completion ===
-        .state("Ensure customer satisfaction and wrap up", id="completion", type="summary")
+        .next_state("final_summary")
+        # === STATE: final_summary ===
+        .state("final summary: ensure customer satisfaction and wrap up", type="summary")
         .required(["issue resolved confirmation", "follow up if needed"])
         .success_condition("Customer satisfaction confirmed")
     )
@@ -269,12 +269,12 @@ class Pathways:
             completion_criteria="User's problem is resolved",
             fallback_strategy="If problem is complex, escalate to specialized support"
         )
-        # === STATE: intake ===
-        .state("Understand the problem", id="intake")
+        # === STATE: problem_intake ===
+        .state("problem intake: understand the issue details")
         .required(["issue description"])
-        .next_state("solution")
-        # === STATE: solution ===
-        .state("Provide solution", id="solution")
+        .next_state("provide_solution")
+        # === STATE: provide_solution ===
+        .state("provide solution: offer targeted assistance")
         .success_condition("User's problem is resolved")
     )
     ```
@@ -342,11 +342,15 @@ class Pathways:
         ----------
         desc
             Clear description of the state's purpose and what should happen. This is the primary
-            identifier and should be specific about the expected interaction or outcome.
+            identifier and should be specific about the expected interaction or outcome. Supports
+            semantic sugar: use `"id: description"` format to specify both ID and description in
+            one parameter (e.g., `"completion: ensure customer satisfaction and wrap up"`). The ID
+            part will be automatically normalized (spaces converted to underscores, etc.).
         id
             Optional unique identifier for the state. Required only when other states need to
             reference this state (via `.branch_on()`, `.next_state()`). If not
-            provided, an ID will be auto-generated from the description.
+            provided, an ID will be auto-generated from the description. Ignored if `desc` uses
+            the `"id: description"` format.
         type
             Optional explicit state type. If not provided, the type will be inferred from subsequent
             method calls
@@ -379,6 +383,8 @@ class Pathways:
         -----------------
         - **Description Priority**: description always comes first as the primary identifier
         - **Reference Requirements**: ID only needed when other states need to reference this state
+        - **Semantic Sugar**: use `"id: description"` format to combine ID and description in one
+        parameter for cleaner syntax; ID part is automatically normalized (spaces → underscores)
         - **Type Inference**: inferred from usage patterns to reduce explicit configuration
         - **Conflict Resolution**: first method call determines type, conflicts generate warnings
         - **Auto-generation**: IDs use `snake_case` from description with uniqueness guarantees
@@ -396,7 +402,7 @@ class Pathways:
 
         Examples
         --------
-        Complete pathway showing `.state()` method creating clear conversation structure:
+        Complete pathway showing `.state()` method with both traditional and semantic sugar syntax:
 
         ```{python}
         import talk_box as tb
@@ -409,22 +415,22 @@ class Pathways:
                 activation="Customer needs product guidance"
             )
 
-            # .state() defines what happens at each step ---
+            # Traditional syntax: separate id parameter ---
             # === STATE: welcome ===
             .state("welcome customer and understand their situation", id="welcome")
             .required(["the customer's goal", "a budget range"])
-            .next_state("analysis")
+            .next_state("needs_analysis")
 
-            # a .state() with a good descriptions makes the flow clear ---
-            # === STATE: analysis ===
-            .state("analyze needs and preferences", id="analysis")
+            # Semantic sugar: "id: description" format ---
+            # === STATE: needs_analysis ===
+            .state("needs analysis: analyze customer requirements and preferences")  # "needs analysis" → "needs_analysis"
             .required(["specific requirements", "priorities"])
             .success_condition("customer needs are clearly understood")
-            .next_state("recommendation")
+            .next_state("final_recommendation")
 
-            # .state() creates the final outcome step ---
-            # === STATE: recommendation ===
-            .state("present tailored recommendations", id="recommendation")
+            # Spaces in ID automatically become underscores ---
+            # === STATE: final_recommendation ===
+            .state("final recommendation: present tailored product matches")  # "final recommendation" → "final_recommendation"
             .required(["product matches", "rationale"])
             .success_condition("customer has clear next steps")
         )
@@ -433,11 +439,32 @@ class Pathways:
         print(pathway)
         ```
         """
-        # Generate ID from description if not provided
+        import re
+
+        # Parse semantic sugar: "id: description" format
+        if id is None and ":" in desc:
+            # Check if desc follows "id: description" pattern
+            parts = desc.split(":", 1)
+            if len(parts) == 2:
+                potential_id = parts[0].strip()
+                # Convert spaces and other non-identifier chars to underscores for valid ID
+                normalized_id = re.sub(r"[^a-zA-Z0-9_]", "_", potential_id)
+                normalized_id = re.sub(r"_+", "_", normalized_id)  # Collapse multiple underscores
+                normalized_id = normalized_id.strip("_")  # Remove leading/trailing underscores
+
+                # Ensure it starts with a letter or underscore
+                if normalized_id and not normalized_id[0].isalpha() and normalized_id[0] != "_":
+                    normalized_id = "_" + normalized_id
+
+                # Use normalized ID if it results in a valid identifier
+                if normalized_id and re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", normalized_id):
+                    id = normalized_id
+                    # Keep the full description including the "id: " prefix
+                    # desc remains unchanged
+
+        # Generate ID from description if still not provided
         if id is None:
             # Create snake_case ID from description
-            import re
-
             id = re.sub(r"[^\w\s]", "", desc.lower())
             id = re.sub(r"\s+", "_", id.strip())
             # Ensure uniqueness

--- a/talk_box/prompt_builder.py
+++ b/talk_box/prompt_builder.py
@@ -3328,18 +3328,18 @@ print(builder)
                 activation=["user reports technical issues", "user needs troubleshooting help"]
             )
             # === STATE: problem_identification ===
-            .state("understand the technical problem", id="problem_identification")
+            .state("understand the technical problem")
             .required(["issue description", "error messages", "recent changes"])
             .next_state("basic_diagnostics")
             # === STATE: basic_diagnostics ===
-            .state("determine if basic fixes might work", id="basic_diagnostics")
+            .state("basic diagnostics: determine if basic fixes might work")
             .branch_on("simple configuration issue", id="quick_fix")
             .branch_on("complex system problem", id="advanced_diagnostics")
             # === STATE: quick_fix ===
-            .state("provide immediate solution steps", id="quick_fix")
+            .state("quick fix: provide immediate solution steps")
             .success_condition("problem is resolved")
             # === STATE: advanced_diagnostics ===
-            .state("perform detailed system analysis", id="advanced_diagnostics")
+            .state("advanced diagnostics: perform detailed system analysis")
             .success_condition("root cause identified and resolved")
         )
 


### PR DESCRIPTION
This PR implements a shorthand syntax for defining state IDs in the `.state()` method, allowing users to write `"id: description"` format instead of separate `id=` parameters.