### PR TITLE
feat: persona-aware default guards

### DIFF
--- a/talk_box/__init__.py
+++ b/talk_box/__init__.py
@@ -41,6 +41,7 @@ from talk_box.guardrails import (
     max_response_length,
     must_cite_sources,
     no_pii,
+    resolve_guards,
     tone_check,
 )
 from talk_box.pathways import Pathways
@@ -111,6 +112,7 @@ __all__ = [
     "max_response_length",
     "must_cite_sources",
     "no_pii",
+    "resolve_guards",
     "tone_check",
     # Evaluation
     "eval",

--- a/talk_box/builder.py
+++ b/talk_box/builder.py
@@ -1079,7 +1079,7 @@ class ChatBot:
 
         return self
 
-    def persona_pack(self, name: str) -> "ChatBot":
+    def persona_pack(self, name: str, *, default_guards: bool = True) -> "ChatBot":
         """
         Load a complete, production-ready persona configuration.
 
@@ -1092,11 +1092,18 @@ class ChatBot:
         `persona_pack()` builds a full `PromptBuilder`-based system prompt using
         research-backed attention patterns (primacy bias, clustering, recency bias).
 
+        Personas may also declare default guardrails (e.g., PII detection,
+        disclaimers) that are applied automatically. Pass `default_guards=False`
+        to skip them.
+
         Parameters
         ----------
         name
             The persona name (e.g., `"customer_support_tier1"`, `"code_reviewer"`).
             Use `talk_box.personas.list_personas()` to see all available names.
+        default_guards
+            Whether to apply the persona's default guardrails. Defaults to
+            `True`. Set to `False` to load the persona without any automatic guards.
 
         Returns
         -------
@@ -1113,6 +1120,7 @@ class ChatBot:
         >>> import talk_box as tb
         >>> bot = tb.ChatBot().persona_pack("code_reviewer")
         >>> bot = tb.ChatBot().persona_pack("customer_support_tier1").model("ollama:llama4")
+        >>> bot = tb.ChatBot().persona_pack("financial_advisor", default_guards=False)
         """
         from talk_box.personas import get_persona
 
@@ -1136,6 +1144,13 @@ class ChatBot:
         if persona.tools:
             existing_tools = self._config.get("tools") or []
             self._config["tools"] = list(set(existing_tools + persona.tools))
+
+        # Apply default guardrails from persona definition
+        if default_guards and persona.default_guards:
+            from talk_box.guardrails import resolve_guards
+
+            for guard in resolve_guards(persona.default_guards):
+                self.guardrail(guard)
 
         # Store metadata for introspection
         self._config["persona_pack"] = name

--- a/talk_box/guardrails.py
+++ b/talk_box/guardrails.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Optional, Protocol
+from typing import Any, Callable, Optional, Protocol
 
 # ---------------------------------------------------------------------------
 # Core types

--- a/talk_box/guardrails.py
+++ b/talk_box/guardrails.py
@@ -699,3 +699,70 @@ def keyword_block(
         return GuardResult.passed()
 
     return Guard(name="keyword_block", func=_check, phase=phase)
+
+
+# ---------------------------------------------------------------------------
+# Guard resolution from declarative specs
+# ---------------------------------------------------------------------------
+
+# Registry of built-in guard factory functions
+GUARD_FACTORIES: dict[str, Any] = {
+    "no_pii": no_pii,
+    "max_response_length": max_response_length,
+    "tone_check": tone_check,
+    "disclaimer_required": disclaimer_required,
+    "must_cite_sources": must_cite_sources,
+    "max_input_length": max_input_length,
+    "keyword_block": keyword_block,
+}
+
+
+def resolve_guards(specs: list[str | dict[str, Any]]) -> list[Guard]:
+    """Create Guard instances from declarative guard specifications.
+
+    Guard specs are either a plain string (guard name, no arguments) or a
+    dict with a single key (guard name) whose value is a dict of keyword
+    arguments to pass to the factory function.
+
+    Parameters
+    ----------
+    specs
+        List of guard specifications. Each is either a string naming a
+        built-in guard (e.g., `"no_pii"`) or a single-key dict mapping
+        the guard name to its keyword arguments (e.g.,
+        `{"disclaimer_required": {"disclaimer_text": "..."}}`).
+
+    Returns
+    -------
+    list[Guard]
+        Instantiated guards ready to add to a pipeline.
+
+    Raises
+    ------
+    ValueError
+        If a guard name is not found in the registry.
+    TypeError
+        If a spec has an unsupported type.
+    """
+    guards: list[Guard] = []
+
+    for spec in specs:
+        if isinstance(spec, str):
+            factory = GUARD_FACTORIES.get(spec)
+            if factory is None:
+                raise ValueError(f"Unknown guard '{spec}'. Available: {sorted(GUARD_FACTORIES)}")
+            guards.append(factory())
+        elif isinstance(spec, dict):
+            if len(spec) != 1:
+                raise ValueError(
+                    f"Guard spec dict must have exactly one key, got {len(spec)}: {spec}"
+                )
+            name, kwargs = next(iter(spec.items()))
+            factory = GUARD_FACTORIES.get(name)
+            if factory is None:
+                raise ValueError(f"Unknown guard '{name}'. Available: {sorted(GUARD_FACTORIES)}")
+            guards.append(factory(**kwargs))
+        else:
+            raise TypeError(f"Guard spec must be a str or dict, got {type(spec).__name__}")
+
+    return guards

--- a/talk_box/personas/_loader.py
+++ b/talk_box/personas/_loader.py
@@ -70,6 +70,10 @@ class PersonaDefinition:
         Default temperature for this persona.
     max_tokens
         Default max token limit for this persona.
+    default_guards
+        Guardrail specs applied automatically by ``persona_pack()``.
+        Each entry is a guard name string or a dict mapping a guard name
+        to its keyword arguments.
     tags
         Free-form tags for filtering and discovery.
     test_queries
@@ -117,6 +121,7 @@ class PersonaDefinition:
     recommended_models: list[ModelRecommendation] = field(default_factory=list)
     temperature: float | None = None
     max_tokens: int | None = None
+    default_guards: list[str | dict[str, Any]] = field(default_factory=list)
 
     # Metadata
     tags: list[str] = field(default_factory=list)
@@ -235,6 +240,7 @@ def _parse_persona(data: dict[str, Any]) -> PersonaDefinition:
         recommended_models=models,
         temperature=data.get("temperature"),
         max_tokens=data.get("max_tokens"),
+        default_guards=data.get("default_guards", []),
         tags=data.get("tags", []),
         test_queries=data.get("test_queries", []),
     )

--- a/talk_box/personas/packs/customer_support_tier1.yaml
+++ b/talk_box/personas/packs/customer_support_tier1.yaml
@@ -54,6 +54,9 @@ recommended_models:
 temperature: 0.3
 max_tokens: 500
 
+default_guards:
+  - no_pii
+
 tags:
   - customer-service
   - support

--- a/talk_box/personas/packs/financial_advisor.yaml
+++ b/talk_box/personas/packs/financial_advisor.yaml
@@ -54,6 +54,11 @@ recommended_models:
 temperature: 0.2
 max_tokens: 700
 
+default_guards:
+  - no_pii
+  - disclaimer_required:
+      disclaimer_text: "This is educational information, not personalized financial advice. Consult a licensed financial professional for guidance specific to your situation."
+
 tags:
   - finance
   - budgeting

--- a/talk_box/personas/packs/hr_advisor.yaml
+++ b/talk_box/personas/packs/hr_advisor.yaml
@@ -53,6 +53,11 @@ recommended_models:
 temperature: 0.2
 max_tokens: 600
 
+default_guards:
+  - no_pii
+  - disclaimer_required:
+      disclaimer_text: "This is general HR guidance. Consult your organization's HR department or an employment attorney for advice specific to your situation."
+
 tags:
   - hr
   - human-resources

--- a/talk_box/personas/packs/legal_info.yaml
+++ b/talk_box/personas/packs/legal_info.yaml
@@ -54,6 +54,11 @@ recommended_models:
 temperature: 0.1
 max_tokens: 800
 
+default_guards:
+  - no_pii
+  - disclaimer_required:
+      disclaimer_text: "This is general legal information, not legal advice. Consult a qualified attorney for advice specific to your situation."
+
 tags:
   - legal
   - compliance

--- a/talk_box/personas/packs/sales_assistant.yaml
+++ b/talk_box/personas/packs/sales_assistant.yaml
@@ -51,6 +51,9 @@ recommended_models:
 temperature: 0.4
 max_tokens: 600
 
+default_guards:
+  - no_pii
+
 tags:
   - sales
   - consultative

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -15,6 +15,7 @@ from talk_box.guardrails import (
     max_response_length,
     must_cite_sources,
     no_pii,
+    resolve_guards,
     tone_check,
 )
 
@@ -667,3 +668,162 @@ class TestMockResponses:
         bot = ChatBot().mock_responses(["resp"]).model("gpt-4")
         convo = bot.chat("test")
         assert convo.get_last_message().content == "resp"
+
+
+# ---------------------------------------------------------------------------
+# resolve_guards tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveGuards:
+    def test_resolve_string_spec(self):
+        guards = resolve_guards(["no_pii"])
+        assert len(guards) == 1
+        assert guards[0].name == "no_pii"
+
+    def test_resolve_dict_spec_with_kwargs(self):
+        guards = resolve_guards([{"disclaimer_required": {"disclaimer_text": "Not advice."}}])
+        assert len(guards) == 1
+        assert guards[0].name == "disclaimer_required"
+        # Verify the guard actually works
+        result = guards[0].check("Hello")
+        assert result.action == GuardAction.REWRITTEN
+        assert "Not advice." in result.message
+
+    def test_resolve_multiple_specs(self):
+        guards = resolve_guards(
+            [
+                "no_pii",
+                {"disclaimer_required": {"disclaimer_text": "Disclaimer."}},
+            ]
+        )
+        assert len(guards) == 2
+        assert guards[0].name == "no_pii"
+        assert guards[1].name == "disclaimer_required"
+
+    def test_resolve_empty_list(self):
+        guards = resolve_guards([])
+        assert guards == []
+
+    def test_resolve_unknown_guard_string(self):
+        with pytest.raises(ValueError, match="Unknown guard 'nonexistent'"):
+            resolve_guards(["nonexistent"])
+
+    def test_resolve_unknown_guard_dict(self):
+        with pytest.raises(ValueError, match="Unknown guard 'nonexistent'"):
+            resolve_guards([{"nonexistent": {}}])
+
+    def test_resolve_dict_with_multiple_keys(self):
+        with pytest.raises(ValueError, match="exactly one key"):
+            resolve_guards([{"no_pii": {}, "tone_check": {}}])
+
+    def test_resolve_invalid_type(self):
+        with pytest.raises(TypeError, match="str or dict"):
+            resolve_guards([42])
+
+    def test_resolve_all_builtin_guards(self):
+        specs = [
+            "no_pii",
+            {"max_response_length": {"max_chars": 100}},
+            {"tone_check": {"expected_tone": "professional"}},
+            {"disclaimer_required": {"disclaimer_text": "Test."}},
+            "must_cite_sources",
+            {"max_input_length": {"max_chars": 500}},
+            {"keyword_block": {"keywords": ["bad"]}},
+        ]
+        guards = resolve_guards(specs)
+        assert len(guards) == 7
+
+
+# ---------------------------------------------------------------------------
+# Persona-aware guard defaults tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaDefaultGuards:
+    def test_financial_advisor_gets_guards(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("financial_advisor")
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" in stats
+
+    def test_financial_advisor_disclaimer_works(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("financial_advisor").mock_responses(["Save 20% of income."])
+        convo = bot.chat("How do I save?")
+        content = convo.get_last_message().content
+        assert "not personalized financial advice" in content
+
+    def test_legal_info_gets_guards(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("legal_info")
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" in stats
+
+    def test_legal_info_disclaimer_works(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("legal_info").mock_responses(["Fair use allows limited use."])
+        convo = bot.chat("What is fair use?")
+        content = convo.get_last_message().content
+        assert "not legal advice" in content
+
+    def test_hr_advisor_gets_guards(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("hr_advisor")
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" in stats
+
+    def test_customer_support_gets_pii_only(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("customer_support_tier1")
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" not in stats
+
+    def test_sales_assistant_gets_pii_only(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("sales_assistant")
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" not in stats
+
+    def test_code_reviewer_gets_no_guards(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("code_reviewer")
+        stats = bot.guard_stats()
+        assert stats == {}
+
+    def test_default_guards_false_skips_guards(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("financial_advisor", default_guards=False)
+        stats = bot.guard_stats()
+        assert stats == {}
+
+    def test_pii_guard_fires_on_persona_bot(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("customer_support_tier1").mock_responses(["I'll help you."])
+        convo = bot.chat("My email is test@example.com")
+        user_msg = convo.get_messages()[0]
+        assert "[EMAIL]" in user_msg.content
+
+    def test_manual_guard_added_after_persona_defaults(self):
+        from talk_box import ChatBot
+
+        bot = ChatBot().persona_pack("financial_advisor").guardrail(max_response_length(50))
+        stats = bot.guard_stats()
+        assert "no_pii" in stats
+        assert "disclaimer_required" in stats
+        assert "max_response_length" in stats

--- a/user_guide/guardrails.qmd
+++ b/user_guide/guardrails.qmd
@@ -60,6 +60,10 @@ That single chain adds three layers of protection:
 
 The guards run automatically on every message and no additional code is required at the point of interaction.
 
+::: {.callout-note}
+The `financial_advisor` persona already ships with `no_pii()` and a disclaimer as [default guards](#persona-default-guards). The example above adds them explicitly to illustrate how manual stacking works.
+:::
+
 ## How Guards Work
 
 At their core, guards are functions that inspect text and decide what to do with it. Each guard takes a string and returns a `GuardResult` indicating whether the text should pass through, be blocked, or be rewritten.
@@ -301,6 +305,75 @@ print(f"Reason: {result.reason}")
 ```
 
 The keyword check is case-insensitive by default. Pass `case_sensitive=True` for exact matching when needed.
+
+## Persona Default Guards
+
+Some personas ship with guardrails pre-configured. When you load a persona with `persona_pack()`, its default guards are applied automatically, so you get sensible protection without manually stacking guards.
+
+For example, the `financial_advisor` persona auto-applies `no_pii()` and a domain-appropriate disclaimer:
+
+```{python}
+#| eval: false
+import talk_box as tb
+
+# PII protection and disclaimer are applied automatically
+bot = tb.ChatBot().persona_pack("financial_advisor")
+```
+
+```{python}
+#| echo: false
+import talk_box as tb
+
+bot = (
+    tb.ChatBot()
+    .persona_pack("financial_advisor")
+    .mock_responses([
+        "Start with an emergency fund covering 3-6 months of expenses, "
+        "then contribute to your employer's 401(k) up to the match."
+    ])
+)
+
+convo = bot.chat("How should I start saving?")
+print(convo.get_last_message().content)
+```
+
+The following personas include default guards:
+
+| Persona | Default Guards |
+|---------|---------------|
+| `financial_advisor` | `no_pii`, disclaimer (not personalized financial advice) |
+| `legal_info` | `no_pii`, disclaimer (not legal advice) |
+| `hr_advisor` | `no_pii`, disclaimer (general HR guidance) |
+| `customer_support_tier1` | `no_pii` |
+| `sales_assistant` | `no_pii` |
+
+Personas in the `technical`, `creative`, `data`, and `education` categories have no default guards, since their domains rarely involve sensitive personal data or liability concerns.
+
+You can always add more guards on top of the defaults:
+
+```{python}
+#| eval: false
+import talk_box as tb
+
+bot = (
+    tb.ChatBot()
+    .persona_pack("financial_advisor")       # Gets no_pii + disclaimer
+    .guardrail(tb.tone_check("professional"))  # Add your own on top
+    .guardrail(tb.max_response_length(500))
+)
+```
+
+To skip the persona's default guards entirely, pass `default_guards=False`:
+
+```{python}
+#| eval: false
+import talk_box as tb
+
+# Load the persona's prompt and config, but not its guards
+bot = tb.ChatBot().persona_pack("financial_advisor", default_guards=False)
+```
+
+This is useful when you need full control over the guard stack, or when testing the persona's raw behavior without guardrail intervention.
 
 ## Writing Custom Guards
 


### PR DESCRIPTION
This PR enhances the persona system by enabling personas to declare default guardrails (such as PII detection and disclaimers) that are automatically applied when loading a persona with `persona_pack()`. The PR also adds a new `resolve_guards` utility for declarative guard instantiation. On top of this, we update persona definitions to specify their default guards. Docs and tests are updated to cover these new features. Finally, users can now opt out of default guards when loading a persona.