### PR TITLE
feat: add `eval_model_update()`

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -216,6 +216,7 @@ reference:
     contents:
       - eval
       - eval_regression
+      - eval_model_update
       - eval_suite
       - EvalCase
       - EvalDimension

--- a/talk_box/__init__.py
+++ b/talk_box/__init__.py
@@ -25,6 +25,7 @@ from talk_box.eval import (
     EvalResults,
     EvalScore,
     eval,
+    eval_model_update,
     eval_regression,
     eval_suite,
     scorecard_table,
@@ -119,6 +120,7 @@ __all__ = [
     "tone_check",
     # Evaluation
     "eval",
+    "eval_model_update",
     "eval_regression",
     "eval_suite",
     "EvalCase",

--- a/talk_box/eval.py
+++ b/talk_box/eval.py
@@ -819,6 +819,100 @@ def eval_suite(
     return results
 
 
+def eval_model_update(
+    persona: str,
+    *,
+    before: str,
+    after: str,
+    queries: list[str | EvalCase] | None = None,
+    dimensions: list[EvalDimension] | None = None,
+    judge: str | "ChatBot | None" = None,
+    threshold: float = 0.05,
+    default_guards: bool = True,
+    scorecard_path: str | Path | None = None,
+) -> EvalResults:
+    """Compare persona behavior across two model versions.
+
+    A convenience wrapper around `eval_suite()` that builds two bot variants from
+    the same persona (one per model string) and flags any dimensions where
+    the newer model regresses compared to the older one.
+
+    Parameters
+    ----------
+    persona
+        Persona name to evaluate (e.g., `"code_reviewer"`).
+    before
+        Provider:model string for the baseline model (e.g., `"anthropic:claude-sonnet-4-5"`).
+    after
+        Provider:model string for the new model (e.g., `"anthropic:claude-sonnet-4-6"`).
+    queries
+        Queries to evaluate. Falls back to persona `test_queries`.
+    dimensions
+        Scoring dimensions. Defaults to relevance, safety, instruction_adherence.
+    judge
+        Judge model string or ChatBot.
+    threshold
+        Score drop to flag as a regression (default 0.05 = 5%).
+    default_guards
+        Whether to apply persona default guards.
+    scorecard_path
+        If provided, writes the scorecard JSON to this path.
+
+    Returns
+    -------
+    EvalResults
+        Results with two variants (named after the model strings). Use
+        `.regressions(baseline=before, threshold=threshold)` to inspect dimension-level drops, or
+        `.to_great_table()` / `.scorecard_table()` for a visual comparison.
+
+    Raises
+    ------
+    ValueError
+        If `before=` and `after=` are the same string.
+
+    Examples
+    --------
+    ```python
+    import talk_box as tb
+
+    results = tb.eval_model_update(
+        "code_reviewer",
+        before="anthropic:claude-sonnet-4-5",
+        after="anthropic:claude-sonnet-4-6",
+        judge="anthropic:claude-sonnet-4-6",
+    )
+
+    # Check for regressions
+    drops = results.regressions()
+    if drops:
+        print("Regressions detected:", drops)
+
+    # Visual comparison
+    results.to_great_table()
+    ```
+    """
+    if before == after:
+        raise ValueError(f"'before' and 'after' must be different models, got: {before!r}")
+
+    results = eval_suite(
+        persona,
+        models=[before, after],
+        queries=queries,
+        dimensions=dimensions,
+        judge=judge,
+        default_guards=default_guards,
+        scorecard_path=scorecard_path,
+    )
+
+    # Enrich config with model-update metadata
+    results.config["type"] = "model_update"
+    results.config["before"] = before
+    results.config["after"] = after
+    results.config["regression_threshold"] = threshold
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -933,8 +1027,7 @@ def scorecard_table(source: str | Path | dict[str, Any]) -> "gt.GT":
     """
     if not HAS_GREAT_TABLES:
         raise ImportError(
-            "great_tables is required for scorecard_table(). "
-            "Install with: pip install great_tables"
+            "great_tables is required for scorecard_table(). Install with: pip install great_tables"
         )
     if not HAS_PANDAS:
         raise ImportError(
@@ -1033,13 +1126,10 @@ def sweep_table(source: str | Path | dict[str, Any]) -> "gt.GT":
     """
     if not HAS_GREAT_TABLES:
         raise ImportError(
-            "great_tables is required for sweep_table(). "
-            "Install with: pip install great_tables"
+            "great_tables is required for sweep_table(). Install with: pip install great_tables"
         )
     if not HAS_PANDAS:
-        raise ImportError(
-            "pandas is required for sweep_table(). Install with: pip install pandas"
-        )
+        raise ImportError("pandas is required for sweep_table(). Install with: pip install pandas")
 
     data = _load_json_source(source)
     sweep_results = data.get("results", [])

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -15,6 +15,7 @@ from talk_box.eval import (
     _resolve_queries,
     eval,
     eval_regression,
+    eval_model_update,
     eval_suite,
     scorecard_table,
     sweep_table,
@@ -967,3 +968,131 @@ class TestSweepTable:
         html = table.as_raw_html()
         assert "m1" in html
         assert "m2" in html
+
+
+# ---------------------------------------------------------------------------
+# eval_model_update tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvalModelUpdate:
+    def test_basic(self):
+        judge = ChatBot(name="Judge").mock_responses(
+            [
+                "relevance: 0.85 | Good\nsafety: 1.0 | Safe\n"
+                "instruction_adherence: 0.80 | Follows instructions",
+                "relevance: 0.90 | Great\nsafety: 1.0 | Safe\n"
+                "instruction_adherence: 0.88 | Very good",
+            ]
+        )
+
+        results = eval_model_update(
+            "code_reviewer",
+            before="openai:gpt-4o",
+            after="anthropic:claude-sonnet-4-6",
+            queries=["Review this function"],
+            judge=judge,
+        )
+
+        assert len(results.variants) == 2
+        assert "openai:gpt-4o" in results.variants
+        assert "anthropic:claude-sonnet-4-6" in results.variants
+        assert results.config["type"] == "model_update"
+        assert results.config["before"] == "openai:gpt-4o"
+        assert results.config["after"] == "anthropic:claude-sonnet-4-6"
+        assert results.config["regression_threshold"] == 0.05
+        assert results.config["persona"] == "code_reviewer"
+
+    def test_same_model_raises(self):
+        with pytest.raises(ValueError, match="must be different models"):
+            eval_model_update(
+                "code_reviewer",
+                before="anthropic:claude-sonnet-4-6",
+                after="anthropic:claude-sonnet-4-6",
+            )
+
+    def test_regression_detected(self):
+        judge = ChatBot(name="Judge").mock_responses(
+            [
+                "relevance: 0.95 | Excellent\nsafety: 1.0 | Safe\n"
+                "instruction_adherence: 0.90 | Great",
+                "relevance: 0.60 | Weak\nsafety: 1.0 | Safe\n"
+                "instruction_adherence: 0.70 | Mediocre",
+            ]
+        )
+
+        results = eval_model_update(
+            "code_reviewer",
+            before="openai:gpt-4o",
+            after="openai:gpt-4o-mini",
+            queries=["Review this"],
+            judge=judge,
+            threshold=0.05,
+        )
+
+        regs = results.regressions(baseline="openai:gpt-4o", threshold=0.05)
+        assert "openai:gpt-4o-mini" in regs
+        assert "relevance" in regs["openai:gpt-4o-mini"]
+
+    def test_no_regression(self):
+        judge = ChatBot(name="Judge").mock_responses(
+            [
+                "relevance: 0.85 | Good\nsafety: 1.0 | Safe\ninstruction_adherence: 0.80 | OK",
+                "relevance: 0.90 | Better\nsafety: 1.0 | Safe\ninstruction_adherence: 0.85 | Good",
+            ]
+        )
+
+        results = eval_model_update(
+            "code_reviewer",
+            before="openai:gpt-4o",
+            after="anthropic:claude-sonnet-4-6",
+            queries=["Review this"],
+            judge=judge,
+        )
+
+        regs = results.regressions(baseline="openai:gpt-4o")
+        assert regs == {}
+
+    def test_custom_dimensions(self):
+        judge = ChatBot(name="Judge").mock_responses(
+            [
+                "relevance: 0.85 | ok\ntone: 0.90 | good",
+                "relevance: 0.88 | ok\ntone: 0.92 | good",
+            ]
+        )
+
+        results = eval_model_update(
+            "code_reviewer",
+            before="openai:gpt-4o",
+            after="anthropic:claude-sonnet-4-6",
+            queries=["Review this"],
+            dimensions=[EvalDimension.RELEVANCE, EvalDimension.TONE],
+            judge=judge,
+        )
+
+        assert len(results.dimensions) == 2
+
+    def test_scorecard_output(self, tmp_path):
+        judge = ChatBot(name="Judge").mock_responses(
+            [
+                "relevance: 0.85 | Good\nsafety: 1.0 | Safe\ninstruction_adherence: 0.80 | ok",
+                "relevance: 0.90 | Great\nsafety: 1.0 | Safe\ninstruction_adherence: 0.88 | good",
+            ]
+        )
+
+        out = tmp_path / "model_update.json"
+        results = eval_model_update(
+            "code_reviewer",
+            before="openai:gpt-4o",
+            after="anthropic:claude-sonnet-4-6",
+            queries=["Review this"],
+            judge=judge,
+            scorecard_path=out,
+        )
+
+        assert out.exists()
+        import json
+
+        loaded = json.loads(out.read_text())
+        assert "openai:gpt-4o" in loaded["variants"]
+        assert "anthropic:claude-sonnet-4-6" in loaded["variants"]

--- a/user_guide/eval.qmd
+++ b/user_guide/eval.qmd
@@ -723,3 +723,83 @@ tb.sweep_table(sweep)
 ```
 
 Both functions accept either a file path or a dict, so they work seamlessly in scripts, notebooks, and Quarto documents. The tables use a red → yellow → green color scale on score columns, making it easy to spot weak spots at a glance.
+
+## Model Version Comparison
+
+When a model provider releases a new version, use `eval_model_update()` to check whether your personas hold up. It runs the same persona against both model versions and flags any dimension that regresses beyond a threshold:
+
+```{python}
+#| eval: false
+import talk_box as tb
+
+results = tb.eval_model_update(
+    "code_reviewer",
+    before="anthropic:claude-sonnet-4-5",
+    after="anthropic:claude-sonnet-4-6",
+    judge="anthropic:claude-sonnet-4-6",
+)
+
+# Inspect regressions (dimensions that dropped > 5%)
+drops = results.regressions()
+if drops:
+    print("Regressions found:", drops)
+else:
+    print("No regressions — safe to upgrade!")
+
+# Visual comparison
+results.to_great_table()
+```
+
+```{python}
+#| echo: false
+import talk_box as tb
+
+bot_before = (
+    tb.ChatBot()
+    .persona_pack("code_reviewer")
+    .mock_responses(["The function looks correct but could use better naming."])
+)
+bot_after = (
+    tb.ChatBot()
+    .persona_pack("code_reviewer")
+    .mock_responses(["The function has good structure. Variable names are clear."])
+)
+
+judge = tb.ChatBot(name="Judge").mock_responses([
+    "relevance: 0.85 | Identifies issue\n"
+    "safety: 1.0 | Safe\n"
+    "instruction_adherence: 0.82 | Follows code review format",
+    "relevance: 0.90 | More thorough\n"
+    "safety: 1.0 | Safe\n"
+    "instruction_adherence: 0.88 | Good adherence",
+])
+
+results = tb.eval(
+    variants={
+        "anthropic:claude-sonnet-4-5": bot_before,
+        "anthropic:claude-sonnet-4-6": bot_after,
+    },
+    queries=["Review this function for issues"],
+    judge=judge,
+)
+
+drops = results.regressions()
+if drops:
+    print(f"Regressions found: {drops}")
+else:
+    print("No regressions — safe to upgrade!")
+```
+
+You can also write the comparison to a scorecard for tracking over time:
+
+```{python}
+#| eval: false
+results = tb.eval_model_update(
+    "financial_advisor",
+    before="anthropic:claude-sonnet-4-5",
+    after="anthropic:claude-sonnet-4-6",
+    judge="anthropic:claude-sonnet-4-6",
+    scorecard_path="scorecards/model_updates/financial_advisor_4-5_vs_4-6.json",
+)
+tb.scorecard_table(results.to_scorecard())
+```


### PR DESCRIPTION
This PR introduces a new utility function, `eval_model_update()`, to the evaluation framework, allowing users to easily compare persona performance across two model versions and detect regressions. The function is fully integrated into the API, documented in the user guide, and covered by new tests.