### PR TITLE
feat: Ollama detection

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -246,6 +246,14 @@ reference:
       - register_model
       - model_profiles_table
 
+  - title: Ollama Detection
+    desc: Auto-detect local Ollama instances and register available models.
+    contents:
+      - OllamaStatus
+      - detect_ollama
+      - list_ollama_models
+      - sync_ollama_models
+
 # Site Settings
 site:
   theme: flatly

--- a/talk_box/__init__.py
+++ b/talk_box/__init__.py
@@ -51,10 +51,14 @@ from talk_box.guardrails import (
 from talk_box.models import (
     CostTier,
     ModelProfile,
+    OllamaStatus,
+    detect_ollama,
     get_model_profile,
     list_models,
+    list_ollama_models,
     model_profiles_table,
     register_model,
+    sync_ollama_models,
 )
 from talk_box.pathways import Pathways
 from talk_box.personas import PersonaDefinition, get_persona, list_personas, persona_categories
@@ -141,10 +145,15 @@ __all__ = [
     # Model profiles
     "ModelProfile",
     "CostTier",
+    "OllamaStatus",
     "get_model_profile",
     "list_models",
     "register_model",
     "model_profiles_table",
+    # Ollama
+    "detect_ollama",
+    "list_ollama_models",
+    "sync_ollama_models",
     # Prompt engineering
     "PromptBuilder",
     "Priority",

--- a/talk_box/models.py
+++ b/talk_box/models.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -645,3 +648,278 @@ def model_profiles_table() -> "gt.GT":
     )
 
     return table
+
+
+# ---------------------------------------------------------------------------
+# Ollama detection & setup
+# ---------------------------------------------------------------------------
+
+_OLLAMA_DEFAULT_URL = "http://localhost:11434"
+
+
+@dataclass
+class OllamaStatus:
+    """Status of the local Ollama instance.
+
+    Parameters
+    ----------
+    available
+        Whether Ollama is reachable.
+    url
+        The base URL that was checked.
+    version
+        Ollama server version string, if available.
+    models
+        List of model names currently pulled/available.
+    error
+        Error message if Ollama is not reachable.
+    """
+
+    available: bool
+    url: str
+    version: str = ""
+    models: list[str] | None = None
+    error: str = ""
+
+
+def detect_ollama(url: str | None = None, *, timeout: float = 2.0) -> OllamaStatus:
+    """Detect whether a local Ollama instance is running.
+
+    Pings the Ollama HTTP API and returns connection status, server version,
+    and the list of available models.
+
+    Parameters
+    ----------
+    url
+        Base URL for the Ollama API. Defaults to `http://localhost:11434`. Can also be set via the
+        `OLLAMA_HOST` environment variable.
+    timeout
+        Connection timeout in seconds.
+
+    Returns
+    -------
+    OllamaStatus
+        Status object with availability, version, and model list.
+
+    Examples
+    --------
+    ```python
+    import talk_box as tb
+
+    status = tb.detect_ollama()
+    if status.available:
+        print(f"Ollama {status.version} running with {len(status.models)} models")
+        for model in status.models:
+            print(f"  - {model}")
+    else:
+        print(f"Ollama not available: {status.error}")
+    ```
+    """
+    import os
+
+    base_url = url or os.environ.get("OLLAMA_HOST", _OLLAMA_DEFAULT_URL)
+    base_url = base_url.rstrip("/")
+
+    # Check server is reachable
+    try:
+        req = urllib.request.Request(f"{base_url}/api/version", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            version = data.get("version", "")
+    except (urllib.error.URLError, OSError, TimeoutError) as e:
+        return OllamaStatus(
+            available=False,
+            url=base_url,
+            error=str(e),
+        )
+
+    # List available models
+    models: list[str] = []
+    try:
+        req = urllib.request.Request(f"{base_url}/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            for m in data.get("models", []):
+                name = m.get("name", "")
+                if name:
+                    models.append(name)
+    except (urllib.error.URLError, OSError, TimeoutError):
+        pass  # Server is up but /api/tags failed — still report as available
+
+    return OllamaStatus(
+        available=True,
+        url=base_url,
+        version=version,
+        models=sorted(models),
+    )
+
+
+def _parse_ollama_model_details(model_info: dict[str, Any]) -> dict[str, Any]:
+    """Extract capability hints from Ollama model metadata."""
+    details = model_info.get("details") or {}
+    families = details.get("families") or []
+    parameter_size = details.get("parameter_size") or ""
+
+    # Heuristic: determine vision support from family tags
+    supports_vision = any("vision" in f.lower() for f in families)
+
+    # Heuristic: determine tool support (most recent models support it)
+    # Ollama models generally support tools if they're instruct-tuned
+    family = details.get("family") or ""
+    supports_tools = family in (
+        "llama",
+        "qwen2",
+        "gemma",
+        "gemma2",
+        "gemma3",
+        "mistral",
+        "command-r",
+        "phi3",
+        "phi4",
+    )
+
+    # Context window from model info (not always available from /api/tags)
+    # We'll use a conservative default for unknown models
+    context_window = 8_192  # conservative default
+
+    # Known model family context windows
+    context_hints = {
+        "llama": 128_000,
+        "qwen2": 32_768,
+        "gemma": 8_192,
+        "gemma2": 8_192,
+        "gemma3": 128_000,
+        "mistral": 32_768,
+        "command-r": 128_000,
+        "phi3": 128_000,
+        "phi4": 16_384,
+    }
+    if family in context_hints:
+        context_window = context_hints[family]
+
+    return {
+        "supports_vision": supports_vision,
+        "supports_tools": supports_tools,
+        "context_window": context_window,
+        "parameter_size": parameter_size,
+    }
+
+
+def list_ollama_models(
+    url: str | None = None,
+    *,
+    timeout: float = 5.0,
+) -> list[ModelProfile]:
+    """Query Ollama for available models and return their profiles.
+
+    Connects to the Ollama API, retrieves the list of pulled models with their metadata, and returns
+    `ModelProfile` instances for each.
+
+    Parameters
+    ----------
+    url
+        Base URL for the Ollama API. Defaults to `http://localhost:11434` or the `OLLAMA_HOST`
+        environment variable.
+    timeout
+        Connection timeout in seconds.
+
+    Returns
+    -------
+    list[ModelProfile]
+        A profile for each model available in Ollama. Returns an empty list if Ollama is not
+        reachable.
+
+    Examples
+    --------
+    ```python
+    import talk_box as tb
+
+    models = tb.list_ollama_models()
+    for m in models:
+        print(f"{m.model}: {m.context_window:,} tokens, tools={m.supports_tools}")
+    ```
+    """
+    import os
+
+    base_url = url or os.environ.get("OLLAMA_HOST", _OLLAMA_DEFAULT_URL)
+    base_url = base_url.rstrip("/")
+
+    try:
+        req = urllib.request.Request(f"{base_url}/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, TimeoutError):
+        return []
+
+    profiles: list[ModelProfile] = []
+    for model_info in data.get("models", []):
+        name = model_info.get("name", "")
+        if not name:
+            continue
+
+        # Strip :latest tag for cleaner naming
+        display = name.removesuffix(":latest")
+
+        caps = _parse_ollama_model_details(model_info)
+
+        profile = ModelProfile(
+            provider="ollama",
+            model=name,
+            display_name=f"{display} (Ollama)",
+            context_window=caps["context_window"],
+            max_output_tokens=None,
+            supports_tools=caps["supports_tools"],
+            supports_vision=caps["supports_vision"],
+            supports_structured_output=True,  # Ollama supports JSON mode
+            supports_streaming=True,
+            cost_tier=CostTier.FREE,
+            notes=f"Local model; {caps['parameter_size']}"
+            if caps["parameter_size"]
+            else "Local model",
+        )
+        profiles.append(profile)
+
+    profiles.sort(key=lambda p: p.model)
+    return profiles
+
+
+def sync_ollama_models(
+    url: str | None = None,
+    *,
+    timeout: float = 5.0,
+) -> list[ModelProfile]:
+    """Detect Ollama models and register them in the profile registry.
+
+    Combines `list_ollama_models()` with `register_model()`, and discovered models are added to the
+    global registry so they appear in `list_models(provider="ollama")`, `get_model_profile()`, and
+    `model_profiles_table()`.
+
+    Parameters
+    ----------
+    url
+        Base URL for the Ollama API.
+    timeout
+        Connection timeout in seconds.
+
+    Returns
+    -------
+    list[ModelProfile]
+        The profiles that were registered. Empty if Ollama is unreachable.
+
+    Examples
+    --------
+    ```python
+    import talk_box as tb
+
+    # Sync local models into the registry
+    new_models = tb.sync_ollama_models()
+    print(f"Registered {len(new_models)} Ollama models")
+
+    # Now they're queryable
+    tb.list_models(provider="ollama")
+    ```
+    """
+    profiles = list_ollama_models(url=url, timeout=timeout)
+    for p in profiles:
+        _PROFILES[p.key] = p
+    return profiles

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,11 +3,16 @@ import pytest
 from talk_box.models import (
     CostTier,
     ModelProfile,
+    OllamaStatus,
     _PROFILES,
+    _parse_ollama_model_details,
+    detect_ollama,
     get_model_profile,
     list_models,
+    list_ollama_models,
     model_profiles_table,
     register_model,
+    sync_ollama_models,
 )
 
 
@@ -277,3 +282,319 @@ class TestModelProfilesTable:
         html = table.as_raw_html()
         assert "Model Capability Profiles" in html
         assert "claude-sonnet-4-6" in html or "Claude Sonnet" in html
+
+
+# ---------------------------------------------------------------------------
+# Ollama detection tests
+# ---------------------------------------------------------------------------
+
+# Sample Ollama API responses for mocking
+_MOCK_VERSION_RESPONSE = b'{"version": "0.6.2"}'
+_MOCK_TAGS_RESPONSE = b"""{
+    "models": [
+        {
+            "name": "llama3.3:latest",
+            "details": {
+                "family": "llama",
+                "families": ["llama"],
+                "parameter_size": "70B"
+            }
+        },
+        {
+            "name": "gemma3:27b",
+            "details": {
+                "family": "gemma3",
+                "families": ["gemma3", "vision"],
+                "parameter_size": "27B"
+            }
+        },
+        {
+            "name": "qwen2.5-coder:7b",
+            "details": {
+                "family": "qwen2",
+                "families": ["qwen2"],
+                "parameter_size": "7B"
+            }
+        }
+    ]
+}"""
+
+
+class TestOllamaStatus:
+    def test_available(self):
+        status = OllamaStatus(
+            available=True, url="http://localhost:11434", version="0.6.2", models=["llama3.3"]
+        )
+        assert status.available
+        assert status.version == "0.6.2"
+        assert status.models == ["llama3.3"]
+
+    def test_unavailable(self):
+        status = OllamaStatus(
+            available=False, url="http://localhost:11434", error="Connection refused"
+        )
+        assert not status.available
+        assert "refused" in status.error
+
+
+class TestDetectOllama:
+    def test_ollama_available(self, monkeypatch):
+        """detect_ollama returns status when Ollama is reachable."""
+        import io
+        import urllib.request
+
+        call_count = {"n": 0}
+
+        def mock_urlopen(req, timeout=None):
+            call_count["n"] += 1
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "/api/version" in url:
+                resp = io.BytesIO(_MOCK_VERSION_RESPONSE)
+            else:
+                resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.status = 200
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            resp.read = resp.read
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        status = detect_ollama()
+        assert status.available is True
+        assert status.version == "0.6.2"
+        assert status.url == "http://localhost:11434"
+        assert "llama3.3:latest" in status.models
+        assert "gemma3:27b" in status.models
+        assert len(status.models) == 3
+
+    def test_ollama_unavailable(self, monkeypatch):
+        """detect_ollama returns failure when Ollama is not reachable."""
+        import urllib.error
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        status = detect_ollama()
+        assert status.available is False
+        assert "refused" in status.error.lower()
+
+    def test_custom_url(self, monkeypatch):
+        """detect_ollama uses custom URL."""
+        import io
+        import urllib.request
+
+        captured_urls = []
+
+        def mock_urlopen(req, timeout=None):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            captured_urls.append(url)
+            resp = io.BytesIO(_MOCK_VERSION_RESPONSE if "/version" in url else _MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        detect_ollama(url="http://myhost:9999")
+        assert any("myhost:9999" in u for u in captured_urls)
+
+    def test_env_var_url(self, monkeypatch):
+        """detect_ollama reads OLLAMA_HOST env var."""
+        import io
+        import urllib.request
+
+        captured_urls = []
+
+        def mock_urlopen(req, timeout=None):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            captured_urls.append(url)
+            resp = io.BytesIO(_MOCK_VERSION_RESPONSE if "/version" in url else _MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+        monkeypatch.setenv("OLLAMA_HOST", "http://remote:8080")
+
+        detect_ollama()
+        assert any("remote:8080" in u for u in captured_urls)
+
+
+class TestListOllamaModels:
+    def test_returns_profiles(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        assert len(profiles) == 3
+        assert all(p.provider == "ollama" for p in profiles)
+        assert all(p.cost_tier == CostTier.FREE for p in profiles)
+
+    def test_vision_detection(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        gemma = next(p for p in profiles if "gemma3" in p.model)
+        llama = next(p for p in profiles if "llama3" in p.model)
+        assert gemma.supports_vision is True
+        assert llama.supports_vision is False
+
+    def test_tool_support_detection(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        llama = next(p for p in profiles if "llama3" in p.model)
+        qwen = next(p for p in profiles if "qwen" in p.model)
+        assert llama.supports_tools is True
+        assert qwen.supports_tools is True
+
+    def test_context_window_from_family(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        llama = next(p for p in profiles if "llama3" in p.model)
+        qwen = next(p for p in profiles if "qwen" in p.model)
+        assert llama.context_window == 128_000
+        assert qwen.context_window == 32_768
+
+    def test_unreachable_returns_empty(self, monkeypatch):
+        import urllib.error
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        assert profiles == []
+
+    def test_sorted_output(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = list_ollama_models()
+        names = [p.model for p in profiles]
+        assert names == sorted(names)
+
+
+class TestSyncOllamaModels:
+    def test_registers_in_global(self, monkeypatch):
+        import io
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            resp = io.BytesIO(_MOCK_TAGS_RESPONSE)
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        # Remove any existing ollama:llama3.3:latest from built-in registry
+        _PROFILES.pop("ollama:llama3.3:latest", None)
+
+        profiles = sync_ollama_models()
+        assert len(profiles) == 3
+
+        # Should now be findable
+        found = get_model_profile("ollama:llama3.3:latest")
+        assert found is not None
+        assert found.provider == "ollama"
+
+        # Cleanup
+        for p in profiles:
+            _PROFILES.pop(p.key, None)
+
+    def test_unreachable_noop(self, monkeypatch):
+        import urllib.error
+        import urllib.request
+
+        def mock_urlopen(req, timeout=None):
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+        profiles = sync_ollama_models()
+        assert profiles == []
+
+
+class TestParseOllamaModelDetails:
+    def test_llama_family(self):
+        info = {"details": {"family": "llama", "families": ["llama"], "parameter_size": "70B"}}
+        caps = _parse_ollama_model_details(info)
+        assert caps["supports_tools"] is True
+        assert caps["supports_vision"] is False
+        assert caps["context_window"] == 128_000
+
+    def test_vision_family(self):
+        info = {
+            "details": {
+                "family": "gemma3",
+                "families": ["gemma3", "vision"],
+                "parameter_size": "27B",
+            }
+        }
+        caps = _parse_ollama_model_details(info)
+        assert caps["supports_vision"] is True
+        assert caps["context_window"] == 128_000
+
+    def test_unknown_family(self):
+        info = {"details": {"family": "exotic", "families": ["exotic"], "parameter_size": "3B"}}
+        caps = _parse_ollama_model_details(info)
+        assert caps["supports_tools"] is False
+        assert caps["context_window"] == 8_192  # conservative default
+
+    def test_empty_details(self):
+        info = {}
+        caps = _parse_ollama_model_details(info)
+        assert caps["supports_tools"] is False
+        assert caps["supports_vision"] is False
+        assert caps["context_window"] == 8_192


### PR DESCRIPTION
This PR adds first-class support for local Ollama model detection and registration. It introduces new utilities to automatically discover, profile, and register Ollama models, making them available alongside other model providers.